### PR TITLE
Update docs to reflect AppleScript architecture

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,14 +7,14 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ```bash
 swift build              # Build all targets
 swift run Hush           # Build and run the app
-swift test               # Run all tests (15 tests)
+swift test               # Run all tests (17 tests)
 swift test --filter SpotifyAdClassifierTests   # Run ad classifier tests only
 swift test --filter MonitorStateTests          # Run state machine tests only
 ```
 
 ## Project Overview
 
-Hush is a macOS menu bar app (Swift/SwiftUI, macOS 13+) that detects Spotify ads via Apple's private MediaRemote framework and reduces system volume to a configurable floor, restoring it when music resumes. Volume is reduced (not muted) because Spotify detects muting and pauses playback.
+Hush is a macOS menu bar app (Swift/SwiftUI, macOS 13+) that detects Spotify ads and reduces system volume to a configurable floor, restoring it when music resumes. Volume is reduced (not muted) because Spotify detects muting and pauses playback.
 
 ## Architecture
 
@@ -23,18 +23,18 @@ Two SPM targets: **HushCore** (library with all business logic) and **Hush** (ex
 ### Data flow
 
 ```
-MediaRemote notifications → MediaMonitor → AdClassifier → MonitorState → VolumeController
+AppleScript polling → MediaMonitor → AdClassifier → MonitorState → VolumeController
 ```
 
-**MediaRemoteBridge** (singleton) dynamically loads `/System/Library/PrivateFrameworks/MediaRemote.framework` via `dlopen`/`dlsym`. It registers for Now Playing change notifications and provides metadata (title, artist, album, bundle ID, playback rate). Not App Store eligible due to private API usage.
+**MediaRemoteBridge** (singleton) queries Spotify directly via AppleScript (`NSAppleScript`) on a 2-second polling timer. Returns metadata (title, artist, album, Spotify URL, playback state). Originally used the private MediaRemote framework, but macOS 26 restricts it to Apple-signed binaries.
 
-**MediaMonitor** is the orchestrator. On notification, it fetches metadata from the bridge, classifies it, runs the state machine, and calls VolumeController. It's an `ObservableObject` so SwiftUI can react to state changes.
+**MediaMonitor** is the orchestrator. On each poll, it fetches metadata from the bridge, classifies it, runs the state machine, and calls VolumeController. It's an `ObservableObject` so SwiftUI can react to state changes.
 
 **MonitorState** is a value-type state machine with three states: `idle` (Spotify not playing), `normal` (music playing), `dimmed` (ad detected). The `transition()` method is a pure function that returns a `MonitorAction` (.volumeDimmed, .volumeRestored, .noChange).
 
-**SpotifyAdClassifier** detects ads by checking bundle ID is `com.spotify.client` and metadata matches ad patterns (title "Advertisement"/"Spotify", artist empty/"Spotify"). Conforms to `AdClassifier` protocol for extensibility to other sources.
+**SpotifyAdClassifier** detects ads by checking bundle ID is `com.spotify.client` and either the Spotify URL has a `spotify:ad:` prefix or metadata matches ad patterns (title "Advertisement"/"Spotify", artist empty/"Spotify"). Conforms to `AdClassifier` protocol for extensibility to other sources.
 
-**VolumeController** uses CoreAudio (`kAudioHardwareServiceDeviceProperty_VirtualMainVolume`) for system volume. Dim is instant; restore fades over ~1s via Timer. Monitors external volume changes so user adjustments during ads are preserved.
+**VolumeController** uses CoreAudio (`kAudioHardwareServiceDeviceProperty_VirtualMainVolume`) for system volume. Dim is instant; restore fades over ~1s via Timer.
 
 **AppState** owns MediaMonitor, persists settings to UserDefaults (`isEnabled`, `volumeFloor`, `launchAtLogin`), manages login item via SMAppService.
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ swift run Hush
 
 ## How It Works
 
-Hush monitors macOS Now Playing metadata via the MediaRemote framework. When Spotify switches from music to an advertisement, the system volume is immediately reduced to a configurable floor level (default 5%). When music resumes, volume fades back to the previous level over ~1 second.
+Hush polls Spotify metadata via AppleScript every 2 seconds. When Spotify switches from music to an advertisement (detected by `spotify:ad:` URL prefix or metadata patterns), the system volume is immediately reduced to a configurable floor level (default 5%). When music resumes, volume fades back to the previous level over ~1 second.
 
 Volume is reduced, not muted, because Spotify detects muting and pauses playback.
 


### PR DESCRIPTION
## Summary

- Update CLAUDE.md and README to match current implementation after the macOS 26 ad detection merge
- Replace MediaRemote framework references with AppleScript polling
- Add `spotify:ad:` URL detection to classifier description
- Update test count from 15 to 17
- Remove stale VolumeController external listener description

🤖 Generated with [Claude Code](https://claude.com/claude-code)